### PR TITLE
Adds composition support to EasyParams

### DIFF
--- a/lib/easy_params.rb
+++ b/lib/easy_params.rb
@@ -2,6 +2,7 @@
 
 require 'active_model'
 require 'bigdecimal/util'
+require 'easy_params/composition'
 require 'easy_params/types/generic'
 require 'easy_params/types/collection'
 require 'easy_params/types/struct'

--- a/lib/easy_params/composition.rb
+++ b/lib/easy_params/composition.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module EasyParams
+  # Provides composition helpers for EasyParams components.
+  module Composition
+    def self.included(base)
+      base.attr_accessor :owner
+      base.include(InstanceMethods)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods # rubocop:disable Style/Documentation
+      def part_of(owner_name)
+        @owner_name = owner_name
+        alias_method owner_name, :owner
+      end
+    end
+
+    module InstanceMethods # rubocop:disable Style/Documentation
+      def method_missing(name, *attrs, **kwargs, &block)
+        return super unless name.to_s.start_with?('owner_')
+
+        owner_method = name.to_s.sub('owner_', '').to_sym
+        return super unless (handler = owners_chain.lazy.detect { |o| o.public_methods.include?(owner_method) })
+
+        handler.public_send(owner_method, *attrs, **kwargs, &block)
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        return super unless method_name.to_s.start_with?('owner_')
+
+        owners_chain.lazy.any? { |o| o.respond_to?(method_name.to_s.sub('owner_', '').to_sym, include_private) }
+      end
+
+      private
+
+      def owners_chain
+        @owners_chain ||= Enumerator.new do |y|
+          obj = self
+          y << obj = obj.owner while obj.public_methods.include?(:owner)
+        end
+      end
+    end
+  end
+end

--- a/lib/easy_params/types/collection.rb
+++ b/lib/easy_params/types/collection.rb
@@ -41,6 +41,8 @@ module EasyParams
 
     # base interface for array of structs type
     class StructsCollection < Collection
+      include EasyParams::Composition
+
       def read_default
         @default
       end

--- a/spec/composition_spec.rb
+++ b/spec/composition_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Owner
+  def check_name?
+    true
+  end
+
+  def check_address_city?
+    true
+  end
+
+  def check_address_zip?
+    false
+  end
+
+  def check_phone_number?
+    true
+  end
+end
+
+RSpec.describe EasyParams::Composition do
+  describe 'composition' do
+    let(:params_class) do
+      Class.new(EasyParams::Base) do
+        integer :id
+        string :name, presence: { if: :owner_check_name? }
+        has :address do
+          string :street
+          string :city, presence: { if: :owner_check_address_city? }
+          string :state
+          string :zip, presence: { if: :owner_check_address_zip? }
+        end
+        each :phones do
+          string :number, presence: { if: :owner_check_phone_number? }
+          string :type
+        end
+      end
+    end
+
+    it 'allows composition of attributes' do
+      owner = Owner.new
+      params = params_class.new(id: 1, address: { street: '123 Main St', city: nil, state: 'CA' }, phones: [{ number: nil, type: 'home' }, { number: '098-765-4321', type: 'work' }])
+      params.owner = owner
+      expect(params).to be_invalid
+      expect(params.errors[:name]).to include("can't be blank")
+      expect(params.address.errors[:city]).to include("can't be blank")
+      expect(params.phones[0].errors[:number]).to include("can't be blank")
+      expect(params.owner).to eq owner
+      expect(params.address.owner).to eq params
+      expect(params.phones.owner).to eq params
+      expect(params.phones[0].owner).to eq(params.phones)
+      expect(params.phones[1].owner).to eq(params.phones)
+    end
+  end
+end


### PR DESCRIPTION
Introduces composition to EasyParams, allowing nested params objects to access methods of their parent objects.

This enables validation logic within nested params to depend on the state or methods of their owners, creating more flexible and contextual validation rules.

Specifically, it introduces `EasyParams::Composition` module and includes it in `EasyParams::Base` and `EasyParams::Types::StructsCollection`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `Composition` with `owner_*` delegation and wires owner propagation for nested structs and collections, with tests.
> 
> - **Core (Composition)**:
>   - Add `EasyParams::Composition` with `owner` accessor, `part_of`, and `owner_*` delegation via `method_missing`/`respond_to_missing?`.
> - **Integration**:
>   - Include `Composition` in `EasyParams::Base` and `Types::StructsCollection`.
>   - In `Base#initialize`, set `owner` on nested `has` structs, `each` collections, and their items.
>   - Require `easy_params/composition` in `lib/easy_params.rb`.
> - **Tests**:
>   - Add `spec/composition_spec.rb` covering validation via owner delegation and ownership links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e192bdd584fd4be7ed910c4e3c0422392233872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->